### PR TITLE
Fix debug macro in logger

### DIFF
--- a/common/logger/logger.cpp
+++ b/common/logger/logger.cpp
@@ -262,7 +262,7 @@ Logger::Log Logger::debug()
 }
 QString Logger::sensitive(const QString &input)
 {
-#ifdef Q_DEBUG
+#ifdef QT_DEBUG
     return input;
 #else
     Q_UNUSED(input);


### PR DESCRIPTION
## Summary
- correct the debug macro check in logger

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_6840923e1fac83339e8b570728720c79